### PR TITLE
Fix wrong password_reuse_prevention variable

### DIFF
--- a/iam_passwordpolicy.tf
+++ b/iam_passwordpolicy.tf
@@ -6,7 +6,7 @@ resource "aws_iam_account_password_policy" "strict" {
     require_numbers = true
     require_symbols = true
     allow_users_to_change_password = true
-    password_reuse_prevention = "${var.password_min_length}"
+    password_reuse_prevention = "${var.password_reuse_prevention}"
     hard_expiry = "${var.password_hard_expiry}"
     max_password_age = "${var.password_max_age}"
 }


### PR DESCRIPTION
The variable used for password_reuse_prevention was wrong.
This pull request fixes it.