### PR TITLE
encrypt cloudtrail bucket by default

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,4 @@
 provider "aws" {
   region = "${var.aws_region}"
+  version = "~> 1.6"
 }

--- a/s3_cloudtrail.tf
+++ b/s3_cloudtrail.tf
@@ -2,6 +2,15 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
   bucket = "${local.bucket_name}"
   acl    = "private"
   count  = "${var.trail_bucketname_create}"
+  
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = "${var.trail_bucket_default_encryption_key}"
+        sse_algorithm     = "${var.trail_bucket_default_encryption}"
+      }
+    }
+  }
 }
 
 resource "aws_s3_bucket_policy" "cloudtrail_bucket_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,13 @@ variable "trail_bucketname_create" {
   description = "Defines if the bucket should be created."
   default     = 1
 }
+
+variable "trail_bucket_default_encryption" {
+  description = "Defines if the Bucket is encrypted, defaults to AES256"
+  default     = "AES256"
+}
+
+variable "trail_bucket_default_encryption_key" {
+  description = "Defines if the KMS encryption key, used if trail_bucket_default_encryption is set to aws:kms"
+  default     = ""
+}


### PR DESCRIPTION
This encrypts the cloudtrail bucket by default with AES256 and leaves the option to use a custom KMS key.