### PR TITLE
Block public access to cloudtrail bucket

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 * n.a.
 
 IMPROVEMENTS:
-* n.a.
+* Add Public Access Block for Cloudtrail S3 Bucket
 
 BUG FIXES:
 * n.a.

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
   region  = "${var.aws_region}"
-  version = "~> 1.6"
+  version = "~> 1.54"
 }

--- a/s3_cloudtrail.tf
+++ b/s3_cloudtrail.tf
@@ -37,3 +37,12 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
 }
 EOF
 }
+
+resource "aws_s3_bucket_public_access_block" "cloudtrail_bucket" {
+  bucket                  = "${aws_s3_bucket.cloudtrail_bucket.id}"
+  count                   = "${var.trail_bucketname_create}"
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
Blocks public access to the cloudtrail bucket with the new aws_s3_bucket_public_access_block resource.
I did not make it optional as i do not see any good reason for the logs to be public.