### PR TITLE
fix interpolation warning in recent tf versions

### DIFF
--- a/s3_cloudtrail.tf
+++ b/s3_cloudtrail.tf
@@ -15,7 +15,7 @@ resource "aws_s3_bucket" "cloudtrail_bucket" {
   tags = merge(
     var.tags,
     {
-      "${var.tag_name}" = local.cloudtrail_bucket_name
+      (var.tag_name) = local.cloudtrail_bucket_name
     }
   )
 


### PR DESCRIPTION
tf 0.13.4 has improved detection of interpolation-only expressions. This gives a warning for this case:
```
Warning: Interpolation-only expressions are deprecated

  on ..... /s3_cloudtrail.tf line 18, in resource "aws_s3_bucket" "cloudtrail_bucket":
  18:       "${var.tag_name}" = local.cloudtrail_bucket_name

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

The  PR fixes the warning